### PR TITLE
Day2: 환경변수, login, OAuth, getSeverSession

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NEXTAUTH_URL="http://localhost:3001"

--- a/app/components/Login.tsx
+++ b/app/components/Login.tsx
@@ -1,8 +1,22 @@
-const Login = () => {
+"use client"; // 클라이언트 컴포넌트로 설정
+
+import { signIn, signOut } from "next-auth/react";
+
+const Login = ({ userInfo }: { userInfo: any }) => {
   return (
-    <div>
-      <button>로그인</button>
-    </div>
+    <>
+      {userInfo ? ( // userInfo 가 있을 경우 (로그인 상태)
+        <div>
+          <button onClick={() => signOut()}>로그아웃</button>
+          <div>
+            <h1>Welcome, {userInfo.name} 😀</h1>
+            <h3>Your email is {userInfo.email} !!</h3>
+          </div>
+        </div>
+      ) : (
+        <button onClick={() => signIn()}>로그인</button>
+      )}
+    </>
   );
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,11 @@ export const metadata: Metadata = {
   description: "Next 공부 기록용 메인 페이지 입니다.",
 };
 
-const MainPage = () => {
+import { getServerSession } from "next-auth";
+import { authOptions } from "../pages/api/auth/[...nextauth].js";
+
+const MainPage = async () => {
+  const res = await getServerSession(authOptions);
   return (
     <div>
       <h2 className="text-2xl flex justify-center p-20 border">메인 페이지</h2>
@@ -41,7 +45,7 @@ const MainPage = () => {
         </li>
       </div>
       <div className="flex justify-center py-20">
-        <Login />
+        <Login userInfo={res?.user} />
       </div>
     </div>
   );

--- a/pages/api/[...nextauth].js
+++ b/pages/api/[...nextauth].js
@@ -1,9 +1,0 @@
-import NextAuth from "next-auth";
-
-import Naver from "next-auth/providers/naver";
-import Google from "next-auth/providers/google";
-import Github from "next-auth/providers/github";
-
-export const authOptions = {
-  providers: [Naver({}), Google({}), Github({})],
-};

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,0 +1,30 @@
+// NextAuth 라이브러리 및 인증 제공자 불러오기
+import NextAuth from "next-auth";
+import Naver from "next-auth/providers/naver"; // 네이버 인증 제공자
+import Google from "next-auth/providers/google"; // 구글 인증 제공자
+import Github from "next-auth/providers/github"; // 깃허브 인증 제공자
+
+// 환경 변수에서 클라이언트 ID와 비밀 키를 가져오는 옵션 객체 설정
+export const authOptions = {
+  providers: [
+    // 네이버 인증 제공자 설정
+    Naver({
+      clientId: process.env.NAVER_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
+      clientSecret: process.env.NAVER_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
+    }),
+    // // 구글 인증 제공자 설정
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
+    }),
+    // 깃허브 인증 제공자 설정
+    Github({
+      clientId: process.env.GITHUB_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
+      clientSecret: process.env.GITHUB_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
+    }),
+  ],
+  secret: "!12@984#alciw&4^5", // JWT 생성 시 쓰는 암호
+};
+
+// NextAuth를 사용하여 인증 기능을 설정하고 내보내기
+export default NextAuth(authOptions);

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -9,18 +9,18 @@ export const authOptions = {
   providers: [
     // 네이버 인증 제공자 설정
     Naver({
-      clientId: process.env.NAVER_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
-      clientSecret: process.env.NAVER_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
+      clientId: process.env.NEXT_PUBLIC_NAVER_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
+      clientSecret: process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
     }),
     // // 구글 인증 제공자 설정
     Google({
-      clientId: process.env.GOOGLE_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
+      clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
+      clientSecret: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
     }),
     // 깃허브 인증 제공자 설정
     Github({
-      clientId: process.env.GITHUB_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
-      clientSecret: process.env.GITHUB_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
+      clientId: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID, // .env 파일에서 클라이언트 ID 가져오기
+      clientSecret: process.env.NEXT_PUBLIC_GITHUB_CLIENT_SECRET, // .env 파일에서 클라이언트 비밀 키 가져오기
     }),
   ],
   secret: "!12@984#alciw&4^5", // JWT 생성 시 쓰는 암호


### PR DESCRIPTION
## NextAuth.js 설정
  - 인증 제공자로 Naver, Google, Github 추가
  - 각 제공자의 클라이언트 ID 및 비밀 키를 환경 변수에서 불러오는 설정을 추가
  - JWT 생성 시 사용할 암호를 설정

## Login 컴포넌트
  - MainPage 컴포넌트에서 사용자 세션을 확인하고 로그인 상태에 따라 적절한 UI를 렌더링하도록 수정
  - 로그인 버튼 클릭 시 NextAuth의 `signIn` 함수 호출하여 사용자가 인증할 수 있도록 했음

## 환경 변수 설정
  - `.env.development` 파일에 `NEXTAUTH_URL` 변수를 추가하여 로컬 개발 환경에서 인증 요청이 올바른 URL로 처리되도록 함
